### PR TITLE
Use HTTPS & skip updating user-specified files

### DIFF
--- a/Client Updater/src/com/simutrans/updater/client/ClientUpdater.java
+++ b/Client Updater/src/com/simutrans/updater/client/ClientUpdater.java
@@ -88,8 +88,8 @@ public class ClientUpdater {
 		mainWindow.setVisible(true);
 	}
 
-	private final static String HASH_URL = "http://bridgewater-brunel.me.uk/downloads/nightly/nightly.hash";
-	private final static String ARCHIVE_URL = "http://bridgewater-brunel.me.uk/downloads/raw/simutrans/";
+	private final static String HASH_URL = "https://bridgewater-brunel.me.uk/downloads/nightly/nightly.hash";
+	private final static String ARCHIVE_URL = "https://bridgewater-brunel.me.uk/downloads/raw/simutrans/";
 	private final static String HASH_NAME = "Simutrans Extended.hash";
 
 	public static void main(String[] args) {

--- a/Client Updater/src/com/simutrans/updater/client/ClientUpdater.java
+++ b/Client Updater/src/com/simutrans/updater/client/ClientUpdater.java
@@ -91,6 +91,7 @@ public class ClientUpdater {
 	private final static String HASH_URL = "https://bridgewater-brunel.me.uk/downloads/nightly/nightly.hash";
 	private final static String ARCHIVE_URL = "https://bridgewater-brunel.me.uk/downloads/raw/simutrans/";
 	private final static String HASH_NAME = "Simutrans Extended.hash";
+	private final static String SKIPLIST_NAME = "Simutrans Extended.skip";
 
 	public static void main(String[] args) {
 		// Application command line state.
@@ -146,7 +147,7 @@ public class ClientUpdater {
 		// Body.
 		try {
 			final Path rootPath = Paths.get(root);
-			final Updater updater = new Updater(rootPath, new URL(HASH_URL), HASH_NAME, ARCHIVE_URL);
+			final Updater updater = new Updater(rootPath, new URL(HASH_URL), HASH_NAME, ARCHIVE_URL, SKIPLIST_NAME);
 
 			if (cl) {
 				updater.progressSubscription.addSubscription(state -> System.out.println("State: " + state.name()));


### PR DESCRIPTION
I made two improvements for the updater.

First is to use HTTPS since bridgewater-brunel.me.uk now supports it.

Second is the ability to skip updating some files by listing them in `Simutrans Extended.skip`. For example, to not download WIndows executables the skip file could contain:
```
Simutrans-Extended-32.exe
Simutrans-Extended-64.exe
Simutrans-Extended.exe
Makeobj-Extended.exe
pthreadGC2-w32.dll
```
PS: Please license this updater freely.